### PR TITLE
Complete Protoc C# Generation

### DIFF
--- a/dashboard/SpacePi.Dashboard.API/Model/CompileProtobuf.cs
+++ b/dashboard/SpacePi.Dashboard.API/Model/CompileProtobuf.cs
@@ -6,6 +6,11 @@ using System.Threading.Tasks;
 using SpacePi.Dashboard.Analyzer.API;
 
 [assembly: CompileProtobuf(
-    "google/protobuf/descriptor.proto",
-    "google/protobuf/struct.proto"
+    new[] {
+        $"{BuildConfig.CMAKE_CURRENT_SOURCE_DIR}/../../protoc/csharp/include"
+    },
+    new[] {
+        "google/protobuf/descriptor.proto",
+        "google/protobuf/struct.proto"
+    }
 )]

--- a/dashboard/SpacePi.Dashboard.API/Model/DashboardModel.proto
+++ b/dashboard/SpacePi.Dashboard.API/Model/DashboardModel.proto
@@ -4,14 +4,14 @@
 syntax = "proto3";
 
 import "SettingsPage.proto";
-import "transient.proto";
+import "spacepi/protoc/transient.proto";
 import "Widget.proto";
 import "Message.proto";
 
 package SpacePi.Dashboard.API.Model;
 
 message DashboardModel {
-    repeated SettingsPage GlobalSettings = 1 [(transient)=true];
+    repeated SettingsPage GlobalSettings = 1 [(spacepi.protoc.transient)=true];
     Widget Base = 2;
     repeated SettingsPage ProjectSettings = 3;
     map<uint64, Message> Messages = 4;

--- a/dashboard/SpacePi.Dashboard.API/Model/DataField.proto
+++ b/dashboard/SpacePi.Dashboard.API/Model/DataField.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-import "transient.proto";
+import "spacepi/protoc/transient.proto";
 
 import "google/protobuf/descriptor.proto";
 import "google/protobuf/struct.proto";
@@ -9,5 +9,5 @@ package SpacePi.Dashboard.API.Model;
 
 message DataField {
     google.protobuf.FieldDescriptorProto Description = 1;
-    map<uint64, google.protobuf.Value> Instances = 2 [(transient)=true];
+    map<uint64, google.protobuf.Value> Instances = 2 [(spacepi.protoc.transient)=true];
 }

--- a/dashboard/SpacePi.Dashboard.API/Model/ModelPlugin.cs
+++ b/dashboard/SpacePi.Dashboard.API/Model/ModelPlugin.cs
@@ -7,5 +7,6 @@ using System.Threading.Tasks;
 namespace SpacePi.Dashboard.API.Model {
     [Plugin("SpacePi.Dashboard.API.Model", "3.0.0", -9_000_000)]
     public class ModelPlugin : Plugin {
+        public DashboardModel Model { get; } = new();
     }
 }

--- a/dashboard/SpacePi.Dashboard.API/Model/Reflection/ScalarClassField.cs
+++ b/dashboard/SpacePi.Dashboard.API/Model/Reflection/ScalarClassField.cs
@@ -22,7 +22,7 @@ namespace SpacePi.Dashboard.API.Model.Reflection {
 
         public IClass this[int idx] {
             get => Getter();
-            set => Setter((Type) value);
+            set => throw new NotSupportedException();
         }
 
         public readonly NotifyCollectionChangedEventArgs ChangedEvent;
@@ -35,12 +35,11 @@ namespace SpacePi.Dashboard.API.Model.Reflection {
 
         public void Changed() => CollectionChanged?.Invoke(this, ChangedEvent);
 
-        public ScalarClassField(string name, int number, bool transient, Func<Type> getter, Action<Type> setter) {
+        public ScalarClassField(string name, int number, bool transient, Func<Type> getter) {
             Name = name;
             Number = number;
             IsTransient = transient;
             Getter = getter;
-            Setter = setter;
             ChangedEvent = new(NotifyCollectionChangedAction.Replace, this, this, 0);
         }
     }

--- a/dashboard/SpacePi.Dashboard.API/Model/Reflection/VectorEnumField.cs
+++ b/dashboard/SpacePi.Dashboard.API/Model/Reflection/VectorEnumField.cs
@@ -60,11 +60,12 @@ namespace SpacePi.Dashboard.API.Model.Reflection {
             CollectionChanged?.Invoke(this, e);
         }
 
-        public VectorEnumField(string name, int number, bool transient, ObservableCollection<EnumType> list, Func<EnumType, int> toOrdinal, Func<int, EnumType> fromOrdinal) {
+        public VectorEnumField(string name, int number, bool transient, ObservableCollection<EnumType> list, Func<EnumType, int> toOrdinal, Func<int, EnumType> fromOrdinal, IEnum type) {
             Name = name;
             Number = number;
             IsTransient = transient;
             List = new ForgivingList<EnumType>(list);
+            Type = type;
             ToOrdinal = toOrdinal;
             FromOrdinal = fromOrdinal;
             list.CollectionChanged += Changed;

--- a/dashboard/SpacePi.Dashboard.Analyzer.API/BuildConfig.cs.in
+++ b/dashboard/SpacePi.Dashboard.Analyzer.API/BuildConfig.cs.in
@@ -5,14 +5,15 @@ namespace SpacePi.Dashboard.Analyzer.API {
     /// Configuration options set from CMake
     /// </summary>
     public static class BuildConfig {
-        public static readonly string CMAKE_BINARY_DIR = "${CMAKE_BINARY_DIR}";
-        public static readonly string CMAKE_COMMAND = "${CMAKE_COMMAND}";
-        public static readonly string CMAKE_SOURCE_DIR = "${CMAKE_SOURCE_DIR}";
-        public static readonly string Protobuf_PROTOC_EXECUTABLE = "${Protobuf_PROTOC_EXECUTABLE}";
+        public const string CMAKE_BINARY_DIR = "${CMAKE_BINARY_DIR}";
+        public const string CMAKE_COMMAND = "${CMAKE_COMMAND}";
+        public const string CMAKE_CURRENT_SOURCE_DIR = "${CMAKE_CURRENT_SOURCE_DIR}";
+        public const string CMAKE_SOURCE_DIR = "${CMAKE_SOURCE_DIR}";
+        public const string Protobuf_PROTOC_EXECUTABLE = "${Protobuf_PROTOC_EXECUTABLE}";
 
         public static class protoc_gen_spacepi_csharp {
-            public static readonly string TARGET_FILE = "$<TARGET_FILE:protoc-gen-spacepi-csharp>";
-            public static readonly string TARGET_NAME_IF_EXISTS = "$<TARGET_NAME_IF_EXISTS:protoc-gen-spacepi-csharp>";
+            public const string TARGET_FILE = "$<TARGET_FILE:protoc-gen-spacepi-csharp>";
+            public const string TARGET_NAME_IF_EXISTS = "$<TARGET_NAME_IF_EXISTS:protoc-gen-spacepi-csharp>";
         }
     }
 }

--- a/dashboard/SpacePi.Dashboard.Analyzer.API/CompileProtobufAttribute.cs
+++ b/dashboard/SpacePi.Dashboard.Analyzer.API/CompileProtobufAttribute.cs
@@ -13,8 +13,9 @@ namespace SpacePi.Dashboard.Analyzer.API {
         /// <summary>
         /// Attribute constructor
         /// </summary>
+        /// <param name="includeDirs">A list of extra system include search paths</param>
         /// <param name="systemFiles">A list of system files to include in the compilation</param>
-        public CompileProtobufAttribute(params string[] systemFiles) {
+        public CompileProtobufAttribute(string[] includeDirs, string[] systemFiles) {
         }
     }
 }

--- a/dashboard/SpacePi.Dashboard.Analyzer/Protobuf/BuildConfiguration.cs
+++ b/dashboard/SpacePi.Dashboard.Analyzer/Protobuf/BuildConfiguration.cs
@@ -25,6 +25,10 @@ namespace SpacePi.Dashboard.Analyzer.Protobuf {
         /// </summary>
         public readonly string StampFile;
         /// <summary>
+        /// A list of extra system include search paths
+        /// </summary>
+        public readonly string[] IncludeDirs;
+        /// <summary>
         /// A list of system files to include in the compilation
         /// </summary>
         public readonly string[] SystemFiles;
@@ -61,7 +65,8 @@ namespace SpacePi.Dashboard.Analyzer.Protobuf {
             SourceDir = Path.GetDirectoryName(attr.ApplicationSyntaxReference.SyntaxTree.FilePath);
             OutputDir = $"{BuildConfig.CMAKE_BINARY_DIR}/_dashboard/{nameof(SpacePi)}.{nameof(Dashboard)}.{nameof(Analyzer)}/{nameof(Protobuf)}/{SourceDir.Substring(BuildConfig.CMAKE_SOURCE_DIR.Length + 1)}";
             StampFile = $"{OutputDir}/.stamp";
-            SystemFiles = attr.ConstructorArguments.FirstOrDefault().Values.Select(s => s.Value.ToString()).ToArray();
+            IncludeDirs = attr.ConstructorArguments[0].Values.Select(s => s.Value.ToString()).ToArray();
+            SystemFiles = attr.ConstructorArguments[1].Values.Select(s => s.Value.ToString()).ToArray();
         }
     }
 }

--- a/dashboard/SpacePi.Dashboard.Analyzer/Protobuf/ProtobufAnalyzer.cs
+++ b/dashboard/SpacePi.Dashboard.Analyzer/Protobuf/ProtobufAnalyzer.cs
@@ -151,7 +151,7 @@ namespace SpacePi.Dashboard.Analyzer.Protobuf {
             Directory.CreateDirectory(config.OutputDir);
             if (SpawnProcess(
                 BuildConfig.Protobuf_PROTOC_EXECUTABLE,
-                $"-I \"{config.SourceDir}\" \"--spacepi-csharp_out={config.OutputDir}\"{string.Join("", paths.Select(f => f.Substring(config.SourceDir.Length + 1)).Concat(config.SystemFiles).Select(f => $" \"{f.Replace('\\', '/')}\""))}",
+                $"{string.Join("", config.IncludeDirs.Concat(new[] { config.SourceDir }).Select(d => $"-I \"{d}\" "))}\"--spacepi-csharp_out={config.OutputDir}\"{string.Join("", paths.Select(f => f.Substring(config.SourceDir.Length + 1)).Concat(config.SystemFiles).Select(f => $" \"{f.Replace('\\', '/')}\""))}",
                 Path.GetDirectoryName(BuildConfig.protoc_gen_spacepi_csharp.TARGET_FILE),
                 paths,
                 Context.Diagnostics.ProtocBuildStatus,

--- a/dashboard/SpacePi.Dashboard.Analyzer/Protobuf/ProtobufAnalyzer.cs
+++ b/dashboard/SpacePi.Dashboard.Analyzer/Protobuf/ProtobufAnalyzer.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
@@ -17,6 +17,17 @@ namespace SpacePi.Dashboard.Analyzer.Protobuf {
     /// The logic to compile protobuf code
     /// </summary>
     public class ProtobufAnalyzer {
+        /// <summary>
+        /// A list of regular expressions to use for parsing file names and line numbers out of the diagnostic logs
+        /// </summary>
+        private static readonly Regex[] DiagnosticFileRegexes = new Regex[] {
+            new("^([A-Z]:\\\\[^(]+)\\(([0-9]+),([0-9]+)\\): "),
+            new("^([A-Z]:\\\\[^(]+)\\(([0-9]+)\\): "),
+            new("^([A-Z]:\\\\[^ ]+) : "),
+            new("^([^.]+\\.proto):([0-9]+):([0-9]+): "),
+            new("^([^.]+\\.proto):([0-9]+): "),
+            new("^([^.]+\\.proto): ")
+        };
         /// <summary>
         /// The compilation context
         /// </summary>
@@ -33,26 +44,29 @@ namespace SpacePi.Dashboard.Analyzer.Protobuf {
         /// <param name="line">The line of output to parse</param>
         /// <param name="files">A list of possible source files which could have diagnostics reported</param>
         private void ParseDiagnostic(Diagnostics.Type diag, string line, IEnumerable<string> files) {
-            string[] parts = line.Split(new[] { ':' }, 2);
-            string file = files.FirstOrDefault(f => f.EndsWith(parts[0]));
+#if PROTOBUF_DEBUG
+            Console.WriteLine(line);
+#endif
             Location loc = null;
-            if (file != null && parts.Length == 2) {
-                int colNo = 1;
-                line = parts[1];
-                parts = parts[1].Split(new[] { ':' }, 2);
-                if (int.TryParse(parts[0], out int lineNo) && parts.Length == 2) {
-                    line = parts[1];
-                    parts = parts[1].Split(new[] { ':' }, 2);
-                    if (int.TryParse(parts[0], out colNo) && parts.Length == 2) {
-                        line = parts[1];
-                    } else {
-                        colNo = 1;
+            foreach (Regex regex in DiagnosticFileRegexes) {
+                Match match = regex.Match(line);
+                if (match.Success) {
+                    string file = files.FirstOrDefault(f => f.EndsWith(match.Groups[1].Value));
+                    switch (match.Groups.Count) {
+                        case 2:
+                            loc = Location.Create(file, new(), new());
+                            break;
+                        case 3: {
+                            LinePosition pos = new(int.Parse(match.Groups[2].Value) - 1, 0);
+                            loc = Location.Create(file, new(), new(pos, pos));
+                        } break;
+                        case 4: {
+                            LinePosition pos = new(int.Parse(match.Groups[2].Value) - 1, int.Parse(match.Groups[3].Value) - 1);
+                            loc = Location.Create(file, new(), new(pos, pos));
+                        } break;
                     }
-                } else {
-                    lineNo = 1;
+                    break;
                 }
-                LinePosition pos = new(lineNo - 1, colNo - 1);
-                loc = Location.Create(file, new TextSpan(), new LinePositionSpan(pos, pos));
             }
             diag.Report(loc, line);
         }
@@ -92,7 +106,7 @@ namespace SpacePi.Dashboard.Analyzer.Protobuf {
             stdout.Wait();
             stderr.Wait();
             foreach (string line in stdout.Result.Split('\n').Select(l => l.Trim()).Where(l => l.Length > 0)) {
-                ParseDiagnostic(stdoutDiag, line, files);
+                ParseDiagnostic(line.ToLower().Contains("error") ? stderrDiag : stdoutDiag, line, files);
             }
             foreach (string line in stderr.Result.Split('\n').Select(l => l.Trim()).Where(l => l.Length > 0)) {
                 ParseDiagnostic(stderrDiag, line, files);
@@ -103,7 +117,8 @@ namespace SpacePi.Dashboard.Analyzer.Protobuf {
         /// <summary>
         /// Builds the protoc plugin with CMake
         /// </summary>
-        private void BuildPlugin() => SpawnProcess(
+        /// <returns>If the build was successful</returns>
+        private bool BuildPlugin() => SpawnProcess(
             BuildConfig.CMAKE_COMMAND,
             $"--build \"{BuildConfig.CMAKE_BINARY_DIR}\" --target {BuildConfig.protoc_gen_spacepi_csharp.TARGET_NAME_IF_EXISTS}",
             null,
@@ -168,7 +183,9 @@ namespace SpacePi.Dashboard.Analyzer.Protobuf {
                 if (NeedsRebuild(config.Key, config.Value)) {
                     if (!hasBuiltPlugin) {
                         hasBuiltPlugin = true;
-                        BuildPlugin();
+                        if (!BuildPlugin()) {
+                            break;
+                        }
                     }
                     if (!File.Exists(BuildConfig.protoc_gen_spacepi_csharp.TARGET_FILE)) {
                         break;

--- a/dashboard/SpacePi.Dashboard.Core/DeveloperTools/DeveloperToolsPlugin.cs
+++ b/dashboard/SpacePi.Dashboard.Core/DeveloperTools/DeveloperToolsPlugin.cs
@@ -12,7 +12,8 @@ namespace SpacePi.Dashboard.Core.DeveloperTools {
     class TestClass : ModelClass, IObject {
         public IClass Reflection => this;
 
-        public TestClass(string name, params IField[] fields) : base(name, fields) {
+        public TestClass(string name, params IField[] fields) : base(name) {
+            Fields = Fields;
         }
     }
 

--- a/dashboard/SpacePi.Dashboard.Core/DeveloperTools/DeveloperToolsPlugin.cs
+++ b/dashboard/SpacePi.Dashboard.Core/DeveloperTools/DeveloperToolsPlugin.cs
@@ -15,7 +15,7 @@ namespace SpacePi.Dashboard.Core.DeveloperTools {
 
         [BindPlugin]
         public ModelPlugin Model {
-            set => Root = new ScalarClassNode(new ScalarClassField<DashboardModel>("Dashboard Model", 0, false, () => value.Model, _ => throw new NotSupportedException()));
+            set => Root = new ScalarClassNode(new ScalarClassField<DashboardModel>("Dashboard Model", 0, false, () => value.Model));
         }
     }
 }

--- a/dashboard/SpacePi.Dashboard.Core/DeveloperTools/DeveloperToolsPlugin.cs
+++ b/dashboard/SpacePi.Dashboard.Core/DeveloperTools/DeveloperToolsPlugin.cs
@@ -9,37 +9,13 @@ using SpacePi.Dashboard.API.Model;
 using SpacePi.Dashboard.API.Model.Reflection;
 
 namespace SpacePi.Dashboard.Core.DeveloperTools {
-    class TestClass : ModelClass, IObject {
-        public IClass Reflection => this;
-
-        public TestClass(string name, params IField[] fields) : base(name) {
-            Fields = fields;
-        }
-    }
-
     [Plugin("SpacePi.Dashboard.Core.DeveloperTools", "3.0.0", 11_002_000)]
     public class DeveloperToolsPlugin : Plugin {
         public IGroupNode Root { get; private set; }
 
         [BindPlugin]
         public ModelPlugin Model {
-            set {
-                ObservableCollection<int> myIntList = new();
-                myIntList.Add(1);
-                myIntList.Add(2);
-                myIntList.Add(4);
-                int enumField = 1;
-                double scalarDouble = 1.23;
-                TestClass subClassField = new("SubClassField",
-                    new ScalarEnumField("EnumField", 0, false, new ModelEnum("Fruit", (0, "Apple"), (1, "Banana"), (2, "Cherry")), () => enumField, v => enumField = v),
-                    new ScalarPrimitiveField("ScalarDouble", 0, false, IPrimitiveField.Types.Double, () => scalarDouble, v => scalarDouble = (double) v)
-                );
-                TestClass model = new("TestingModelClass",
-                    new VectorPrimitiveField<int>("MyIntList", 0, false, IPrimitiveField.Types.Int32, myIntList),
-                    new ScalarClassField<TestClass>("SubClassField", 0, false, () => subClassField, v => subClassField = v)
-                );
-                Root = new ScalarClassNode(new ScalarClassField<TestClass>("Dashboard Model", 0, false, () => model, _ => throw new NotSupportedException()));
-            }
+            set => Root = new ScalarClassNode(new ScalarClassField<DashboardModel>("Dashboard Model", 0, false, () => value.Model, _ => throw new NotSupportedException()));
         }
     }
 }

--- a/dashboard/SpacePi.Dashboard.Core/DeveloperTools/DeveloperToolsPlugin.cs
+++ b/dashboard/SpacePi.Dashboard.Core/DeveloperTools/DeveloperToolsPlugin.cs
@@ -13,7 +13,7 @@ namespace SpacePi.Dashboard.Core.DeveloperTools {
         public IClass Reflection => this;
 
         public TestClass(string name, params IField[] fields) : base(name) {
-            Fields = Fields;
+            Fields = fields;
         }
     }
 

--- a/dashboard/SpacePi.Dashboard.Core/DeveloperTools/PrimitiveNode.cs
+++ b/dashboard/SpacePi.Dashboard.Core/DeveloperTools/PrimitiveNode.cs
@@ -17,7 +17,13 @@ namespace SpacePi.Dashboard.Core.DeveloperTools {
             return false;
         }
 
-        protected override string ValueToString() => IPrimitiveField.ToStringers[(int) Field.Type](Field[Index]);
+        protected override string ValueToString() {
+            object val = Field[Index];
+            if (val == null) {
+                return "";
+            }
+            return IPrimitiveField.ToStringers[(int) Field.Type](val);
+        }
 
         public PrimitiveNode(IPrimitiveField field, int index = 0) : base(field, index) {
         }

--- a/dashboard/SpacePi.Dashboard.Test/TestSerializeDeserialize.cs
+++ b/dashboard/SpacePi.Dashboard.Test/TestSerializeDeserialize.cs
@@ -104,7 +104,7 @@ namespace SpacePi.Dashboard.Test {
                                 return new TestModelClass("NameMessage", new IField[] {
                                     new ScalarPrimitiveField("length", 1, false, IPrimitiveField.Types.Uint32, ()=>{ return (uint)1; }, (tmp)=>{ })
                                 });
-                            }, (tmp)=>{ })
+                            })
                     })
                 ),
                 new byte[] { 0x0a, 0x02, 0x08, 0x01 }
@@ -117,7 +117,7 @@ namespace SpacePi.Dashboard.Test {
                                 return new TestModelClass("DataMessage", new IField[] {
                                     new VectorPrimitiveField<uint>("data", 1, false, IPrimitiveField.Types.Uint32, new ObservableCollection<uint>(Enumerable.Repeat((uint)1, 100)))
                                 });
-                            }, (tmp)=>{ })
+                            })
                     })
                 ),
                 Enumerable.Concat(new byte[] { 0x0a, 0b11001000, 0b00000001}, RepeatList(new byte[] { 0x08, 0x01 }, 100))
@@ -187,7 +187,7 @@ namespace SpacePi.Dashboard.Test {
                             return new TestModelClass("DataMessage", new IField[] {
                                 new ScalarPrimitiveField("value", 1, false, IPrimitiveField.Types.Uint32, () => {return 0; }, (val) => { value = (uint)val; } )
                             });
-                        }, (tmp)=>{ })
+                        })
                 })
             );
 

--- a/dashboard/SpacePi.Dashboard.Test/TestSerializeDeserialize.cs
+++ b/dashboard/SpacePi.Dashboard.Test/TestSerializeDeserialize.cs
@@ -13,6 +13,12 @@ using Xunit;
 
 namespace SpacePi.Dashboard.Test {
     public class TestSerializeDeserialize {
+        private class TestModelClass : ModelClass {
+            public TestModelClass(string Name, IEnumerable<IField> fields) : base(Name) {
+                Fields = fields;
+            }
+        }
+
         private static IEnumerable<T> RepeatList<T>(IEnumerable<T> to_repeat, int count) {
             for (int i = 0; i < count; i++) {
                 foreach (T val in to_repeat) {
@@ -85,7 +91,7 @@ namespace SpacePi.Dashboard.Test {
         public static IEnumerable<object[]> GetObjectSerializeData() {
             yield return new object[] {
                 new TestObject(
-                    new ModelClass("Test1", new IField[] {
+                    new TestModelClass("Test1", new List<IField>{
                         new ScalarPrimitiveField("a", 1, false, IPrimitiveField.Types.Uint32, ()=>{ return (uint)150; }, (tmp)=>{ })
                     })
                 ),
@@ -93,9 +99,9 @@ namespace SpacePi.Dashboard.Test {
             };
             yield return new object[] {
                 new TestObject(
-                    new ModelClass("Test1", new IField[] {
+                    new TestModelClass("Test1", new IField[] {
                         new ScalarClassField<ModelClass> ("name", 1, false, ()=>{
-                                return new ModelClass("NameMessage", new IField[] {
+                                return new TestModelClass("NameMessage", new IField[] {
                                     new ScalarPrimitiveField("length", 1, false, IPrimitiveField.Types.Uint32, ()=>{ return (uint)1; }, (tmp)=>{ })
                                 });
                             }, (tmp)=>{ })
@@ -106,9 +112,9 @@ namespace SpacePi.Dashboard.Test {
 
             yield return new object[] {
                 new TestObject(
-                    new ModelClass("RepeatedTest", new IField[] {
+                    new TestModelClass("RepeatedTest", new IField[] {
                         new ScalarClassField<ModelClass> ("data", 1, false, ()=>{
-                                return new ModelClass("DataMessage", new IField[] {
+                                return new TestModelClass("DataMessage", new IField[] {
                                     new VectorPrimitiveField<uint>("data", 1, false, IPrimitiveField.Types.Uint32, new ObservableCollection<uint>(Enumerable.Repeat((uint)1, 100)))
                                 });
                             }, (tmp)=>{ })
@@ -176,9 +182,9 @@ namespace SpacePi.Dashboard.Test {
         public void SimpleDeserializeClass() {
             uint value = 0;
             TestObject test = new TestObject(
-                new ModelClass("RepeatedTest", new IField[] {
+                new TestModelClass("RepeatedTest", new IField[] {
                     new ScalarClassField<ModelClass> ("data", 1, false, ()=>{
-                            return new ModelClass("DataMessage", new IField[] {
+                            return new TestModelClass("DataMessage", new IField[] {
                                 new ScalarPrimitiveField("value", 1, false, IPrimitiveField.Types.Uint32, () => {return 0; }, (val) => { value = (uint)val; } )
                             });
                         }, (tmp)=>{ })
@@ -196,7 +202,7 @@ namespace SpacePi.Dashboard.Test {
         public void SimpleDeserializeList() {
             ObservableCollection<uint> values = new ObservableCollection<uint>();
             TestObject test = new TestObject(
-                new ModelClass("RepeatedTest", new IField[] {
+                new TestModelClass("RepeatedTest", new IField[] {
                     new VectorPrimitiveField<uint>("values", 1, false, IPrimitiveField.Types.Uint32, values),
                 })
             );
@@ -213,7 +219,7 @@ namespace SpacePi.Dashboard.Test {
         public void DeserializeAnotherList() {
             ObservableCollection<uint> values = new ObservableCollection<uint>();
             TestObject test = new TestObject(
-                new ModelClass("RepeatedTest", new IField[] {
+                new TestModelClass("RepeatedTest", new IField[] {
                     new VectorPrimitiveField<uint>("values", 1, false, IPrimitiveField.Types.Uint32, values),
                 })
             );

--- a/protoc/csharp/CMakeLists.txt
+++ b/protoc/csharp/CMakeLists.txt
@@ -1,12 +1,24 @@
 find_package(Protobuf REQUIRED)
 
+add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/include/spacepi/protoc/transient.pb.cc"
+           "${CMAKE_CURRENT_BINARY_DIR}/include/spacepi/protoc/transient.pb.h"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/include"
+    COMMAND protobuf::protoc -I "${CMAKE_CURRENT_SOURCE_DIR}/include" "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}/include" spacepi/protoc/transient.proto
+    MAIN_DEPENDENCY include/spacepi/protoc/transient.proto
+    COMMENT "Running C++ protoc on include/spacepi/protoc/transient.proto"
+    VERBATIM
+)
+
 add_executable(protoc-gen-spacepi-csharp
     src/main.cpp
     src/CSharpGen.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/include/spacepi/protoc/transient.pb.cc
 )
 
 target_include_directories(protoc-gen-spacepi-csharp PUBLIC
     include
+    ${CMAKE_CURRENT_BINARY_DIR}/include
 )
 
 target_link_libraries(protoc-gen-spacepi-csharp

--- a/protoc/csharp/include/spacepi/protoc/CSharpGen.hpp
+++ b/protoc/csharp/include/spacepi/protoc/CSharpGen.hpp
@@ -46,7 +46,7 @@ namespace spacepi {
 
                 // void   getRelfectionPropertyDataBeg  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept;
                 // string   getReflectionPropertyDataMid  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls, const google::protobuf::FieldDescriptor &property) const noexcept;
-                std::string getFullPropertyData(int structureType, std::string propertyType, std::string propertyName, int propertyNumber, const google::protobuf::Descriptor *message_type) const noexcept;
+                std::string getFullPropertyData(int structureType, const google::protobuf::FieldDescriptor &property) const noexcept;
                 std::string getPropertyType(int propertyType) const noexcept;
                 // void   getReflectionPropertyDataEnd  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept;
         };

--- a/protoc/csharp/include/spacepi/protoc/CSharpGen.hpp
+++ b/protoc/csharp/include/spacepi/protoc/CSharpGen.hpp
@@ -25,7 +25,7 @@ namespace spacepi {
                 void fileEnd(CodeStream &os, const google::protobuf::FileDescriptor &file) const noexcept;
 
             private:
-                enum DataType
+                enum class DataType
                 {
                     Class,
                     Enum,
@@ -39,14 +39,15 @@ namespace spacepi {
                         DataType dataType;
 
                         TypeInfo(const std::string &cSharpType, const std::string &primValue, DataType dataType);
+                        TypeInfo(); // makepair needs this constructor
                 };
 
                 static std::unordered_map<google::protobuf::FieldDescriptor::Type, TypeInfo> typeMap;
 
                 // void   getRelfectionPropertyDataBeg  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept;
                 // string   getReflectionPropertyDataMid  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls, const google::protobuf::FieldDescriptor &property) const noexcept;
-                string getFullPropertyData(int structureType, string propertyType, string propertyName, int propertyNumber) const noexcept;
-                string getPropertyType(int propertyType) const noexcept;
+                std::string getFullPropertyData(int structureType, std::string propertyType, std::string propertyName, int propertyNumber, const google::protobuf::Descriptor *message_type) const noexcept;
+                std::string getPropertyType(int propertyType) const noexcept;
                 // void   getReflectionPropertyDataEnd  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept;
         };
     }

--- a/protoc/csharp/include/spacepi/protoc/CSharpGen.hpp
+++ b/protoc/csharp/include/spacepi/protoc/CSharpGen.hpp
@@ -35,6 +35,14 @@ namespace spacepi {
                     Primitive
                 };
 
+                enum class StructureType
+                {
+                    Scalar,
+                    Vector,
+                    ScalarReflection,
+                    VectorReflection
+                };
+
                 class TypeInfo {
                     public:
                         std::string cSharpType;
@@ -47,11 +55,9 @@ namespace spacepi {
 
                 static std::unordered_map<google::protobuf::FieldDescriptor::Type, TypeInfo> typeMap;
 
-                // void   getRelfectionPropertyDataBeg  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept;
-                // string   getReflectionPropertyDataMid  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls, const google::protobuf::FieldDescriptor &property) const noexcept;
-                void getFullPropertyData(CodeStream &os, int structureType, const google::protobuf::FieldDescriptor &property) const noexcept;
+                void getFullPropertyData(CodeStream &os, StructureType type, const google::protobuf::FieldDescriptor &property) const noexcept;
                 std::string getPropertyType(int propertyType) const noexcept;
-                // void   getReflectionPropertyDataEnd  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept;
+                std::string overrideKeyword(std::string propertyName) const noexcept;
         };
     }
 }

--- a/protoc/csharp/include/spacepi/protoc/CSharpGen.hpp
+++ b/protoc/csharp/include/spacepi/protoc/CSharpGen.hpp
@@ -18,6 +18,9 @@ namespace spacepi {
                 void reflectionMethodBeg(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept;
                 void reflectionMethodProperty(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls, const google::protobuf::FieldDescriptor &property) const noexcept;
                 void reflectionMethodEnd(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept;
+                void enumReflectionBeg(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::EnumDescriptor &cls) const noexcept;
+                void enumReflectionValue(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::EnumDescriptor &cls, const google::protobuf::EnumValueDescriptor &value) const noexcept;
+                void enumReflectionEnd(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::EnumDescriptor &cls) const noexcept;
                 void classEnd(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept;
                 void enumBeg(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::EnumDescriptor &cls) const noexcept;
                 void enumValue(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::EnumDescriptor &cls, const google::protobuf::EnumValueDescriptor &value) const noexcept;
@@ -46,7 +49,7 @@ namespace spacepi {
 
                 // void   getRelfectionPropertyDataBeg  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept;
                 // string   getReflectionPropertyDataMid  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls, const google::protobuf::FieldDescriptor &property) const noexcept;
-                std::string getFullPropertyData(int structureType, const google::protobuf::FieldDescriptor &property) const noexcept;
+                void getFullPropertyData(CodeStream &os, int structureType, const google::protobuf::FieldDescriptor &property) const noexcept;
                 std::string getPropertyType(int propertyType) const noexcept;
                 // void   getReflectionPropertyDataEnd  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept;
         };

--- a/protoc/csharp/include/spacepi/protoc/transient.proto
+++ b/protoc/csharp/include/spacepi/protoc/transient.proto
@@ -3,7 +3,7 @@
 
 syntax = "proto2";
 
-package SpacePi.Dashboard.API.Model;
+package spacepi.protoc;
 
 import "google/protobuf/descriptor.proto";
 

--- a/protoc/csharp/src/CSharpGen.cpp
+++ b/protoc/csharp/src/CSharpGen.cpp
@@ -37,20 +37,15 @@ CSharpGen::CSharpGen() noexcept
 }
 
 void CSharpGen::fileBeg(CodeStream &os, const google::protobuf::FileDescriptor &file) const noexcept {
-    os << "// Start file " << file.name() << endl;
     os << "using System;" << endl;
-    os << "using SpacePi.Dashboard.API.Model.Reflection;" << endl;
-    os << "using System.Collections.Generic;" << endl;
-    os << "using System.Collections.ObjectModel;" << endl;
     os << "namespace " << file.package() << " {" << endl
        << indent;
 }
 
 void CSharpGen::classBeg(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept {
-    os << "// Start class " << cls.name() << endl;
-    os << "public class " << cls.name() << " : ModelClass, IObject { " << endl
+    os << "public class " << cls.name() << " : SpacePi.Dashboard.API.Model.Reflection.ModelClass, SpacePi.Dashboard.API.Model.Reflection.IObject { " << endl
        << indent;
-    os << "public IClass Reflection => this;" << endl;
+    os << "public SpacePi.Dashboard.API.Model.Reflection.IClass Reflection => this;" << endl;
 }
 
 void CSharpGen::property(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls, const google::protobuf::FieldDescriptor &property) const noexcept {
@@ -59,21 +54,11 @@ void CSharpGen::property(CodeStream &os, const google::protobuf::FileDescriptor 
     } else {
         getFullPropertyData(os, StructureType::Scalar, property);
     }
-
-    for (int i = 0; i < property.options().uninterpreted_option_size(); i++) {
-        UninterpretedOption uo = property.options().uninterpreted_option(i);
-        os << "/*  UninterpretedOption: ";
-        for (int j = 0; j < uo.name_size(); i++) {
-            os << uo.name(j).name_part() << ".";
-        }
-        os << "  */" << endl;
-    }
 }
 
 void CSharpGen::reflectionMethodBeg(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept {
-    os << endl
-       << "// Start reflection()" << endl;
-    os << "public " << cls.name() << "() : base(\"" << cls.name() << "\") => base.Fields = new IField[] {" << indent << endl;
+    os << endl;
+    os << "public " << cls.name() << "() : base(\"" << cls.name() << "\") => base.Fields = new SpacePi.Dashboard.API.Model.Reflection.IField[] {" << indent << endl;
 }
 
 void CSharpGen::reflectionMethodProperty(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls, const google::protobuf::FieldDescriptor &property) const noexcept {
@@ -82,16 +67,15 @@ void CSharpGen::reflectionMethodProperty(CodeStream &os, const google::protobuf:
     } else {
         getFullPropertyData(os, StructureType::ScalarReflection, property);
     }
-	os << endl;
 }
 
 void CSharpGen::reflectionMethodEnd(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept {
-    os << deindent << "// End reflection()" << endl;
+    os << deindent;
     os << "};" << endl;
 }
 
 void CSharpGen::classEnd(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept {
-    os << deindent << "// End class" << endl;
+    os << deindent;
     os << "}" << endl;
 }
 
@@ -108,12 +92,11 @@ void CSharpGen::enumEnd(CodeStream &os, const google::protobuf::FileDescriptor &
 }
 
 void CSharpGen::fileEnd(CodeStream &os, const google::protobuf::FileDescriptor &file) const noexcept {
-    os << "// End file" << endl;
     os << deindent << "}" << endl;
 }
 
 void CSharpGen::enumReflectionBeg(CodeStream& os, const google::protobuf::FileDescriptor& file, const google::protobuf::EnumDescriptor& cls) const noexcept {
-    os << "public class " << cls.name() << "__Reflection : ModelEnum {" << endl;
+    os << "public class " << cls.name() << "__Reflection : SpacePi.Dashboard.API.Model.Reflection.ModelEnum {" << endl;
     os << indent;
     os << "public " << cls.name() << "__Reflection() : base(\"" << cls.name() << "\"" << endl << indent;
 }
@@ -166,7 +149,7 @@ void CSharpGen::getFullPropertyData(CodeStream &os, StructureType type, const go
             }
             break;
         case StructureType::Vector:
-            os << "public " << overrideKeyword(propertyName) << "ObservableCollection<" + propertyType + "> " + propertyName + " { get; private set; } = new(); " << endl;
+            os << "public " << overrideKeyword(propertyName) << "System.Collections.ObjectModel.ObservableCollection<" + propertyType + "> " + propertyName + " { get; private set; } = new(); " << endl;
             if (property.type() == FieldDescriptor::TYPE_ENUM) {
                 os << "private readonly " << overrideKeyword(propertyName) << propertyType << "__Reflection " << propertyName << "__ReflectionObject = new();" << endl;
             }
@@ -175,13 +158,13 @@ void CSharpGen::getFullPropertyData(CodeStream &os, StructureType type, const go
             switch (property.type()) {
 				case FieldDescriptor::TYPE_MESSAGE:
                 case FieldDescriptor::TYPE_GROUP:
-                    os << "new ScalarClassField<" + propertyType + ">(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", () => { return " + propertyName + "; }, (v) => { " + propertyName + " = (" + propertyType + ")v; }), " << endl;
+                    os << "new SpacePi.Dashboard.API.Model.Reflection.ScalarClassField<" + propertyType + ">(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", () => { return " + propertyName + "; }, (v) => { " + propertyName + " = (" + propertyType + ")v; }), " << endl;
                     break;
                 case FieldDescriptor::TYPE_ENUM:
-                    os << "new ScalarEnumField(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", " + propertyName + "__ReflectionObject, () => { return (int)" + propertyName + "; }, (v) => { " + propertyName + " = (" + propertyType + ")v; }), " << endl;
+                    os << "new SpacePi.Dashboard.API.Model.Reflection.ScalarEnumField(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", " + propertyName + "__ReflectionObject, () => { return (int)" + propertyName + "; }, (v) => { " + propertyName + " = (" + propertyType + ")v; }), " << endl;
                     break;
                 default:
-					os << "new ScalarPrimitiveField(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", IPrimitiveField.Types." + primType + ", () => { return " + propertyName + "; }, (v) => { " + propertyName + " = (" + propertyType + ")v; }), " << endl;
+					os << "new SpacePi.Dashboard.API.Model.Reflection.ScalarPrimitiveField(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", SpacePi.Dashboard.API.Model.Reflection.IPrimitiveField.Types." + primType + ", () => { return " + propertyName + "; }, (v) => { " + propertyName + " = (" + propertyType + ")v; }), " << endl;
                     break;
             }
             break;
@@ -189,13 +172,13 @@ void CSharpGen::getFullPropertyData(CodeStream &os, StructureType type, const go
             switch (property.type()) {
 				case FieldDescriptor::TYPE_MESSAGE:
 				case FieldDescriptor::TYPE_GROUP:
-                    os << "new VectorClassField<" + propertyType + ">(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", " + propertyName + ", () => { return new " + propertyType + "(); }), " << endl;
+                    os << "new SpacePi.Dashboard.API.Model.Reflection.VectorClassField<" + propertyType + ">(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", " + propertyName + ", () => { return new " + propertyType + "(); }), " << endl;
                     break;
                 case FieldDescriptor::TYPE_ENUM:
-                    os << "new VectorEnumField<" + propertyType + ">(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", " + propertyName + ", (e) => { return (int)e; }, (i) => { return (" + propertyType + ")i; }, " + propertyName + "__ReflectionObject ), " << endl;
+                    os << "new SpacePi.Dashboard.API.Model.Reflection.VectorEnumField<" + propertyType + ">(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", " + propertyName + ", (e) => { return (int)e; }, (i) => { return (" + propertyType + ")i; }, " + propertyName + "__ReflectionObject ), " << endl;
                     break;
                 default:
-					os << "new VectorPrimitiveField<" + propertyType + ">(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", IPrimitiveField.Types." + primType + ", " + propertyName + "), " << endl;
+					os << "new SpacePi.Dashboard.API.Model.Reflection.VectorPrimitiveField<" + propertyType + ">(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", SpacePi.Dashboard.API.Model.Reflection.IPrimitiveField.Types." + primType + ", " + propertyName + "), " << endl;
                     break;
             }
             break;

--- a/protoc/csharp/src/CSharpGen.cpp
+++ b/protoc/csharp/src/CSharpGen.cpp
@@ -12,22 +12,22 @@ using namespace spacepi::protoc;
 unordered_map<FieldDescriptor::Type, CSharpGen::TypeInfo> CSharpGen::typeMap = {
     make_pair(FieldDescriptor::TYPE_DOUBLE, CSharpGen::TypeInfo("double", "Double", CSharpGen::DataType::Primitive)),
     make_pair(FieldDescriptor::TYPE_FLOAT, CSharpGen::TypeInfo("float", "Float", CSharpGen::DataType::Primitive)),
-    make_pair(FieldDescriptor::TYPE_INT64, CSharpGen::TypeInfo("long", "Long", CSharpGen::DataType::Primitive)),
-    make_pair(FieldDescriptor::TYPE_UINT64, CSharpGen::TypeInfo("ulong", "Ulong", CSharpGen::DataType::Primitive)),
-    make_pair(FieldDescriptor::TYPE_INT32, CSharpGen::TypeInfo("int", "Int", CSharpGen::DataType::Primitive)),
-    make_pair(FieldDescriptor::TYPE_FIXED64, CSharpGen::TypeInfo("fixed64", "Fixed64", CSharpGen::DataType::Primitive)),
-    make_pair(FieldDescriptor::TYPE_FIXED32, CSharpGen::TypeInfo("fixed32", "Fixed32", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_INT64, CSharpGen::TypeInfo("long", "Int64", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_UINT64, CSharpGen::TypeInfo("ulong", "Uint64", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_INT32, CSharpGen::TypeInfo("int", "Int32", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_FIXED64, CSharpGen::TypeInfo("fixed64", "Uint64", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_FIXED32, CSharpGen::TypeInfo("fixed32", "Uint32", CSharpGen::DataType::Primitive)),
     make_pair(FieldDescriptor::TYPE_BOOL, CSharpGen::TypeInfo("bool", "Bool", CSharpGen::DataType::Primitive)),
     make_pair(FieldDescriptor::TYPE_STRING, CSharpGen::TypeInfo("string", "String", CSharpGen::DataType::Primitive)),
-    make_pair(FieldDescriptor::TYPE_GROUP, CSharpGen::TypeInfo("group", "Group", CSharpGen::DataType::Primitive)),
-    make_pair(FieldDescriptor::TYPE_MESSAGE, CSharpGen::TypeInfo("message", "Message", CSharpGen::DataType::Primitive)),
-    make_pair(FieldDescriptor::TYPE_BYTES, CSharpGen::TypeInfo("byte[]", "Byte[]", CSharpGen::DataType::Primitive)),
-    make_pair(FieldDescriptor::TYPE_UINT32, CSharpGen::TypeInfo("uint", "Uint", CSharpGen::DataType::Primitive)),
-    make_pair(FieldDescriptor::TYPE_ENUM, CSharpGen::TypeInfo("enum", "Enum", CSharpGen::DataType::Primitive)),
-    make_pair(FieldDescriptor::TYPE_SFIXED32, CSharpGen::TypeInfo("sfixed32", "Sfixed32", CSharpGen::DataType::Primitive)),
-    make_pair(FieldDescriptor::TYPE_SFIXED64, CSharpGen::TypeInfo("sfixed64", "Sfixed64", CSharpGen::DataType::Primitive)),
-    make_pair(FieldDescriptor::TYPE_SINT32, CSharpGen::TypeInfo("sint32", "Sint32", CSharpGen::DataType::Primitive)),
-    make_pair(FieldDescriptor::TYPE_SINT64, CSharpGen::TypeInfo("sint64", "Sint64", CSharpGen::DataType::Primitive))
+    make_pair(FieldDescriptor::TYPE_GROUP, CSharpGen::TypeInfo("group", "", CSharpGen::DataType::Class)),
+    make_pair(FieldDescriptor::TYPE_MESSAGE, CSharpGen::TypeInfo("message", "", CSharpGen::DataType::Class)),
+    make_pair(FieldDescriptor::TYPE_BYTES, CSharpGen::TypeInfo("byte[]", "Bytes", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_UINT32, CSharpGen::TypeInfo("uint", "Uint32", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_ENUM, CSharpGen::TypeInfo("enum", "", CSharpGen::DataType::Enum)),
+    make_pair(FieldDescriptor::TYPE_SFIXED32, CSharpGen::TypeInfo("sfixed32", "Int32", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_SFIXED64, CSharpGen::TypeInfo("sfixed64", "Int64", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_SINT32, CSharpGen::TypeInfo("sint32", "Int32", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_SINT64, CSharpGen::TypeInfo("sint64", "Int64", CSharpGen::DataType::Primitive))
 };
 
 CSharpGen::CSharpGen() noexcept
@@ -39,6 +39,7 @@ void CSharpGen::fileBeg(CodeStream &os, const google::protobuf::FileDescriptor &
     os << "using System;" << endl;
     os << "using SpacePi.Dashboard.API.Model.Reflection;" << endl;
     os << "using System.Collections.Generic;" << endl;
+    os << "using System.Collections.ObjectModel;" << endl;
     os << "namespace " << file.package() << " {" << endl
        << indent;
 }
@@ -52,23 +53,23 @@ void CSharpGen::classBeg(CodeStream &os, const google::protobuf::FileDescriptor 
 
 void CSharpGen::property(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls, const google::protobuf::FieldDescriptor &property) const noexcept {
     if (property.is_repeated()) {
-        os << getFullPropertyData(1, typeMap[property.type()].cSharpType, property.name(), property.number(), property.message_type()) << endl;
+        os << getFullPropertyData(1, property) << endl;
     } else {
-        os << getFullPropertyData(0, typeMap[property.type()].cSharpType, property.name(), property.number(), property.message_type()) << endl;
+        os << getFullPropertyData(0, property) << endl;
     }
 }
 
 void CSharpGen::reflectionMethodBeg(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept {
     os << endl
        << "// Start reflection()" << endl;
-    os << "public " << cls.name() << "() : base(\"" << cls.name() << "\") => Fields = new IField[] {" << indent << endl;
+    os << "public " << cls.name() << "() : base(\"" << cls.name() << "\") => base.Fields = new IField[] {" << indent << endl;
 }
 
 void CSharpGen::reflectionMethodProperty(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls, const google::protobuf::FieldDescriptor &property) const noexcept {
     if (property.is_repeated()) {
-        os << getFullPropertyData(3, typeMap[property.type()].cSharpType, property.name(), property.number(), property.message_type()) << endl;
+        os << getFullPropertyData(3, property) << endl;
     } else {
-        os << getFullPropertyData(2, typeMap[property.type()].cSharpType, property.name(), property.number(), property.message_type()) << endl;
+        os << getFullPropertyData(2, property) << endl;
     }
 	os << endl;
 }
@@ -112,28 +113,57 @@ CSharpGen::TypeInfo::TypeInfo()
     : cSharpType(""), primValue(""), dataType(DataType::Primitive) {
 }
 
-string CSharpGen::getFullPropertyData(int structureType, string propertyType, string propertyName, int propertyNumber, const google::protobuf::Descriptor *message_type) const noexcept {
+string CSharpGen::getFullPropertyData(int structureType, const google::protobuf::FieldDescriptor &property) const noexcept {
     // I could have made an enum here for this, but I'm just gonna put the convention for this here for now
     // structureType == 0 is just a normal property
     // structureType == 1 is a normal repeatable property
     // structureType == 2 is a reflected Scalar
     // structureType == 3 is a reflected Vector
-    if (message_type != NULL) {
-        propertyType = message_type->full_name();
+    string propertyType = "";
+    string primType = "";
+    string propertyName = property.name();
+	string propertyNumber = to_string(property.number());
+
+    switch (property.type()) {
+		case FieldDescriptor::TYPE_MESSAGE:
+		case FieldDescriptor::TYPE_GROUP:
+            propertyType = property.message_type()->full_name();
+            break;
+        case FieldDescriptor::TYPE_ENUM:
+			propertyType = property.enum_type()->full_name();
+            break;
+        default:
+            propertyType = typeMap[property.type()].cSharpType;
+            primType = typeMap[property.type()].primValue;
+            break;
     }
 
     switch (structureType) {
         case 0:
             return "public " + propertyType + " " + propertyName + " { get; set; } ";
-            break;
         case 1:
-            return "public List<" + propertyType + "> " + propertyName + " { get; set; } ";
-            break;
+            return "public ObservableCollection<" + propertyType + "> " + propertyName + " { get; private set; } = new();";
         case 2:
-            return "new ScalarPrimitiveField(\"" + propertyName + "\", " + to_string(propertyNumber) + ", false, PrimitiveField.Types." + propertyType + ", () => " + propertyName + ", v => " + propertyName + " = v),";
-            break;
+            switch (property.type()) {
+				case FieldDescriptor::TYPE_MESSAGE:
+                case FieldDescriptor::TYPE_GROUP:
+                    return "new ScalarClassField<" + propertyType + ">(\"" + propertyName + "\", " + propertyNumber + ", false, () => { return " + propertyName + "; }, (v) => { " + propertyName + " = (" + propertyType + ")v; }),";
+                case FieldDescriptor::TYPE_ENUM:
+                    return "#warning Enum reflection not implemented";
+                default:
+					return "new ScalarPrimitiveField(\"" + propertyName + "\", " + propertyNumber + ", false, IPrimitiveField.Types." + primType + ", () => { return " + propertyName + "; }, (v) => { " + propertyName + " = (" + propertyType + ")v; }), ";
+            }
         case 3:
-            return "new VectorPrimitiveField<" + propertyType + ">(\"" + propertyName + "\", " + to_string(propertyNumber) + ", false, " + propertyType + ", " + propertyName + "),";
-            break;
+            switch (property.type()) {
+				case FieldDescriptor::TYPE_MESSAGE:
+				case FieldDescriptor::TYPE_GROUP:
+                    return "new VectorClassField<" + propertyType + ">(\"" + propertyName + "\", " + propertyNumber + ", false, " + propertyName + ", () => { return new " + propertyType + "(); }),";
+                case FieldDescriptor::TYPE_ENUM:
+                    return "#warning Enum reflection not implemented";
+                default:
+					return "new VectorPrimitiveField<" + propertyType + ">(\"" + propertyName + "\", " + propertyNumber + ", false, IPrimitiveField.Types." + primType + ", " + propertyName + "),";
+            }
+        default:
+            return "#error Protobuf compiler encountered unknown structureType " + structureType;
     }
 }

--- a/protoc/csharp/src/CSharpGen.cpp
+++ b/protoc/csharp/src/CSharpGen.cpp
@@ -10,24 +10,24 @@ using namespace google::protobuf;
 using namespace spacepi::protoc;
 
 unordered_map<FieldDescriptor::Type, CSharpGen::TypeInfo> CSharpGen::typeMap = {
-    make_pair(FieldDescriptor::TYPE_DOUBLE, CSharpGen::TypeInfo("double", "Double", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_FLOAT, CSharpGen::TypeInfo("float", "Float", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_INT64, CSharpGen::TypeInfo("long", "Long", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_UINT64, CSharpGen::TypeInfo("ulong", "Ulong", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_INT32, CSharpGen::TypeInfo("int", "Int", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_FIXED64, CSharpGen::TypeInfo("fixed64", "Fixed64", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_FIXED32, CSharpGen::TypeInfo("fixed32", "Fixed32", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_BOOL, CSharpGen::TypeInfo("bool", "Bool", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_STRING, CSharpGen::TypeInfo("string", "String", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_GROUP, CSharpGen::TypeInfo("group", "Group", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_MESSAGE, CSharpGen::TypeInfo("message", "Message", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_BYTES, CSharpGen::TypeInfo("byte[]", "Byte[]", CSharpGen44444444444444::Primitive)),
-    make_pair(FieldDescriptor::TYPE_UINT32, CSharpGen::TypeInfo("uint", "Uint", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_ENUM, CSharpGen::TypeInfo("enum", "Enum", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_SFIXED32, CSharpGen::TypeInfo("sfixed32", "Sfixed32", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_SFIXED64, CSharpGen::TypeInfo("sfixed64", "Sfixed64", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_SINT32, CSharpGen::TypeInfo("sint32", "Sint32", CSharpGen::Primitive)),
-    make_pair(FieldDescriptor::TYPE_SINT64, CSharpGen::TypeInfo("sint64", "Sint64", CSharpGen::Primitive))
+    make_pair(FieldDescriptor::TYPE_DOUBLE, CSharpGen::TypeInfo("double", "Double", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_FLOAT, CSharpGen::TypeInfo("float", "Float", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_INT64, CSharpGen::TypeInfo("long", "Long", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_UINT64, CSharpGen::TypeInfo("ulong", "Ulong", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_INT32, CSharpGen::TypeInfo("int", "Int", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_FIXED64, CSharpGen::TypeInfo("fixed64", "Fixed64", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_FIXED32, CSharpGen::TypeInfo("fixed32", "Fixed32", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_BOOL, CSharpGen::TypeInfo("bool", "Bool", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_STRING, CSharpGen::TypeInfo("string", "String", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_GROUP, CSharpGen::TypeInfo("group", "Group", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_MESSAGE, CSharpGen::TypeInfo("message", "Message", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_BYTES, CSharpGen::TypeInfo("byte[]", "Byte[]", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_UINT32, CSharpGen::TypeInfo("uint", "Uint", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_ENUM, CSharpGen::TypeInfo("enum", "Enum", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_SFIXED32, CSharpGen::TypeInfo("sfixed32", "Sfixed32", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_SFIXED64, CSharpGen::TypeInfo("sfixed64", "Sfixed64", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_SINT32, CSharpGen::TypeInfo("sint32", "Sint32", CSharpGen::DataType::Primitive)),
+    make_pair(FieldDescriptor::TYPE_SINT64, CSharpGen::TypeInfo("sint64", "Sint64", CSharpGen::DataType::Primitive))
 };
 
 CSharpGen::CSharpGen() noexcept
@@ -51,130 +51,10 @@ void CSharpGen::classBeg(CodeStream &os, const google::protobuf::FileDescriptor 
 }
 
 void CSharpGen::property(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls, const google::protobuf::FieldDescriptor &property) const noexcept {
-    os << "// Property " << property.name() << endl;
     if (property.is_repeated()) {
-        // int structureType, string propertyType, string propertyName, int propertyNumber
-        getFullPropertyData(1, to_string(property.type()), property.name(), property.number());
-        // switch (property.type()){
-        // case FieldDescriptor::TYPE_DOUBLE:
-        //     os << "public List<double> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_FLOAT:
-        //     os << "public List<float> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_INT64:
-        //     os << "public List<long> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_UINT64:
-        //     os << "public List<ulong> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_INT32:
-        //     os << "public List<int> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_FIXED64:
-        //     os << "public List<fixed64> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_FIXED32:
-        //     os << "public List<fixed32> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_BOOL:
-        //     os << "public List<bool> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_STRING:
-        //     os << "public List<string> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_GROUP:
-        //     os << "public List<group> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_MESSAGE:
-        //     os << "public List<" << pro666perty.message_type()->full_name() << "> " << property.name() << " { get; set; }" << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_BYTES:
-        //     os << "public List<byte[]> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_UINT32:
-        //     os << "public List<uint> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_ENUM:
-        //     os << "public List<" << property.enum_type()->full_name() << "> " << property.name() << " { get; set; }" << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SFIXED32:
-        //     os << "public List<sfixed32> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SFIXED64:
-        //     os << "public List<sfixed64> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SINT32:
-        //     os << "public List<sint32> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SINT64:
-        //     os << "public List<sint64> " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // default:
-        //     os << "Unknown type - add support!" << endl;
-        //     break;
-        // }
+        os << getFullPropertyData(1, typeMap[property.type()].cSharpType, property.name(), property.number(), property.message_type()) << endl;
     } else {
-        getFullPropertyData(0, to_string(property.type()), property.name(), property.number());
-        // switch (property.type()){
-        // case FieldDescriptor::TYPE_DOUBLE:
-        //     os << "public double " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_FLOAT:
-        //     os << "public float " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_INT64:
-        //     os << "public long " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_UINT64:
-        //     os << "public ulong " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_INT32:
-        //     os << "public int " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_FIXED64:
-        //     os << "public fixed64 " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_FIXED32:
-        //     os << "public fixed32 " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_BOOL:
-        //     os << "public bool " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_STRING:
-        //     os << "public string " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_GROUP:
-        //     os << "public group " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_MESSAGE:
-        //     os << "public " << property.message_type()->full_name() << " " << property.name() << " { get; set; }" << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_BYTES:
-        //     os << "public byte[] " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_UINT32:
-        //     os << "public uint " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_ENUM:
-        //     os << "public " << property.enum_type()->full_name() << " " << property.name() << " { get; set; }" << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SFIXED32:
-        //     os << "public sfixed32 " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SFIXED64:
-        //     os << "public sfixed64 " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SINT32:
-        //     os << "public sint32 " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SINT64:
-        //     os << "public sint64 " << property.name() << " { get; set; } " << endl;
-        //     break;
-        // default:
-        //     os << "Unknown type - debug" << endl;
-        //     break;
-        // }
+        os << getFullPropertyData(0, typeMap[property.type()].cSharpType, property.name(), property.number(), property.message_type()) << endl;
     }
 }
 
@@ -185,132 +65,12 @@ void CSharpGen::reflectionMethodBeg(CodeStream &os, const google::protobuf::File
 }
 
 void CSharpGen::reflectionMethodProperty(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls, const google::protobuf::FieldDescriptor &property) const noexcept {
-    os << "// Property " << property.name() << endl;
     if (property.is_repeated()) {
-        os << "//" << property.type() << endl;
-        os << "//" << to_string(property.type()) << endl;
-        getFullPropertyData(3, to_string(property.type()), property.name(), property.number());
-        // switch (property.type()){
-        // case FieldDescriptor::TYPE_DOUBLE:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Double, " << property.name() << ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_FLOAT:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Float, " << property.name() << ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_INT64:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Int64, " << property.name() << ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_UINT64:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Uint64, " << property.name() << ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_INT32:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Int32, " << property.name() << ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_FIXED64:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, fixed64, " << property.name() << ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_FIXED32:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, fixed32, " << property.name() << ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_BOOL:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Bool, " << property.name() << ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_STRING:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.String, " << property.name() << ")," << endl;
-        //     break;
-        // se FieldDescriptor::TYPE_GROUP:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, group, " << property.name() << ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_MESSAGE:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() << "\", " << property.number() << ", false, " << property.message_type()->full_name() << ", " << property.name() <<  ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_BYTES:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Bytes, " << property.name() << ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_UINT32:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Uint32, " << property.name() << ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_ENUM:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() << "\", " << property.number() << ", false, " << property.enum_type()->full_name() << ", " << property.name() <<  ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SFIXED32:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, sfixed32, " << property.name() << ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SFIXED64:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, sfixed64, " << property.name() << ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SINT32:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, sint32, " << property.name() << ")," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SINT64:
-        //     os << "new VectorPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, sint64, " << property.name() << ")," << endl;
-        //     break;
-        // default:
-        //     os << "Unknown type - debug" << endl;
-        //     break;
-        // }
+        os << getFullPropertyData(3, typeMap[property.type()].cSharpType, property.name(), property.number(), property.message_type()) << endl;
     } else {
-        getFullPropertyData(2, to_string(property.type()), property.name(), property.number());
-        // switch (property.type()){
-        // case FieldDescriptor::TYPE_DOUBLE:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Double, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_FLOAT:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Float, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_INT64:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Int64, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_UINT64:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Uint64, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_INT32:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Int32, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_FIXED64:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, fixed64, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_FIXED32:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, fixed32, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_BOOL:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Bool, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_STRING:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.String, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_GROUP:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, group, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_MESSAGE:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() << "\", " << property.number() << ", false, " << property.message_type()->full_name() << ", () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_BYTES:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Bytes, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_UINT32:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, IPrimitiveField.Types.Uint32, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_ENUM:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() << "\", " << property.number() << ", false, " << property.enum_type()->full_name() << ", () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SFIXED32:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, sfixed32, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SFIXED64:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, sfixed64, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SINT32:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, sint32, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // case FieldDescriptor::TYPE_SINT64:
-        //     os << "new ScalarPrimitiveField" << "(\"" << property.name() <<"\", " << property.number() << ", false, sint64, () => " << property.name() << ", v => " << property.name() << " = v)," << endl;
-        //     break;
-        // default:
-        //     os << "Unknown type - debug" << endl;
-        //     break;
-        // }
+        os << getFullPropertyData(2, typeMap[property.type()].cSharpType, property.name(), property.number(), property.message_type()) << endl;
     }
+	os << endl;
 }
 
 void CSharpGen::reflectionMethodEnd(CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept {
@@ -348,12 +108,20 @@ CSharpGen::TypeInfo::TypeInfo(const string &cSharpType, const string &primValue,
     : cSharpType(cSharpType), primValue(primValue), dataType(dataType) {
 }
 
-string CSharpGen::getFullPropertyData(int structureType, string propertyType, string propertyName, int propertyNumber) const noexcept {
+CSharpGen::TypeInfo::TypeInfo()
+    : cSharpType(""), primValue(""), dataType(DataType::Primitive) {
+}
+
+string CSharpGen::getFullPropertyData(int structureType, string propertyType, string propertyName, int propertyNumber, const google::protobuf::Descriptor *message_type) const noexcept {
     // I could have made an enum here for this, but I'm just gonna put the convention for this here for now
     // structureType == 0 is just a normal property
     // structureType == 1 is a normal repeatable property
     // structureType == 2 is a reflected Scalar
     // structureType == 3 is a reflected Vector
+    if (message_type != NULL) {
+        propertyType = message_type->full_name();
+    }
+
     switch (structureType) {
         case 0:
             return "public " + propertyType + " " + propertyName + " { get; set; } ";

--- a/protoc/csharp/src/CSharpGen.cpp
+++ b/protoc/csharp/src/CSharpGen.cpp
@@ -143,7 +143,15 @@ void CSharpGen::getFullPropertyData(CodeStream &os, StructureType type, const go
 
     switch (type) {
 		case StructureType::Scalar:
-            os << "public " << overrideKeyword(propertyName) << propertyType << " " << propertyName << " { get; set; } " << endl;
+            switch(property.type()) {
+				case FieldDescriptor::TYPE_MESSAGE:
+                case FieldDescriptor::TYPE_GROUP:
+					os << "public " << overrideKeyword(propertyName) << propertyType << " " << propertyName << " { get; } = new();" << endl;
+                    break;
+                default:
+					os << "public " << overrideKeyword(propertyName) << propertyType << " " << propertyName << " { get; set; }" << endl;
+                    break;
+            }
             if (property.type() == FieldDescriptor::TYPE_ENUM) {
                 os << "private readonly " << overrideKeyword(propertyName) << propertyType << "__Reflection " << propertyName << "__ReflectionObject = new();" << endl;
             }
@@ -158,7 +166,7 @@ void CSharpGen::getFullPropertyData(CodeStream &os, StructureType type, const go
             switch (property.type()) {
 				case FieldDescriptor::TYPE_MESSAGE:
                 case FieldDescriptor::TYPE_GROUP:
-                    os << "new SpacePi.Dashboard.API.Model.Reflection.ScalarClassField<" + propertyType + ">(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", () => { return " + propertyName + "; }, (v) => { " + propertyName + " = (" + propertyType + ")v; }), " << endl;
+                    os << "new SpacePi.Dashboard.API.Model.Reflection.ScalarClassField<" + propertyType + ">(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", () => { return " + propertyName + "; }), " << endl;
                     break;
                 case FieldDescriptor::TYPE_ENUM:
                     os << "new SpacePi.Dashboard.API.Model.Reflection.ScalarEnumField(\"" + propertyName + "\", " + propertyNumber + ", " + trans + ", " + propertyName + "__ReflectionObject, () => { return (int)" + propertyName + "; }, (v) => { " + propertyName + " = (" + propertyType + ")v; }), " << endl;

--- a/protoc/lib/include/spacepi/protoc/CodeTemplate.hpp
+++ b/protoc/lib/include/spacepi/protoc/CodeTemplate.hpp
@@ -29,10 +29,6 @@ namespace spacepi {
                 virtual void fileEnd                (CodeStream &os, const google::protobuf::FileDescriptor &file) const noexcept = 0;
 
             private:
-
-                //virtual void   getRelfectionPropertyDataBeg  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept = 0;
-                virtual void getFullPropertyData(CodeStream &os, int structureType, const google::protobuf::FieldDescriptor &property) const noexcept = 0;
-                //virtual void   getReflectionPropertyDataEnd  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept = 0;
                 std::string extension;
         };
     }

--- a/protoc/lib/include/spacepi/protoc/CodeTemplate.hpp
+++ b/protoc/lib/include/spacepi/protoc/CodeTemplate.hpp
@@ -28,7 +28,7 @@ namespace spacepi {
             private:
 
                 //virtual void   getRelfectionPropertyDataBeg  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept = 0;
-                virtual std::string getFullPropertyData (int structureType, string propertyType, string propertyName, int propertyNumber) const noexcept = 0; 
+                virtual std::string getFullPropertyData (int structureType, std::string propertyType, std::string propertyName, int propertyNumber, const google::protobuf::Descriptor *message_type) const noexcept = 0; 
                 //virtual void   getReflectionPropertyDataEnd  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept = 0;
                 std::string extension;
         };

--- a/protoc/lib/include/spacepi/protoc/CodeTemplate.hpp
+++ b/protoc/lib/include/spacepi/protoc/CodeTemplate.hpp
@@ -23,12 +23,15 @@ namespace spacepi {
                 virtual void enumBeg                (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::EnumDescriptor &cls) const noexcept = 0;
                 virtual void enumValue              (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::EnumDescriptor &cls, const google::protobuf::EnumValueDescriptor &value) const noexcept = 0;
                 virtual void enumEnd                (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::EnumDescriptor &cls) const noexcept = 0;
+                virtual void enumReflectionBeg      (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::EnumDescriptor &cls) const noexcept = 0;
+                virtual void enumReflectionValue    (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::EnumDescriptor &cls, const google::protobuf::EnumValueDescriptor &value) const noexcept = 0;
+                virtual void enumReflectionEnd      (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::EnumDescriptor &cls) const noexcept = 0;
                 virtual void fileEnd                (CodeStream &os, const google::protobuf::FileDescriptor &file) const noexcept = 0;
 
             private:
 
                 //virtual void   getRelfectionPropertyDataBeg  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept = 0;
-                virtual std::string getFullPropertyData (int structureType, const google::protobuf::FieldDescriptor &property) const noexcept = 0; 
+                virtual void getFullPropertyData(CodeStream &os, int structureType, const google::protobuf::FieldDescriptor &property) const noexcept = 0;
                 //virtual void   getReflectionPropertyDataEnd  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept = 0;
                 std::string extension;
         };

--- a/protoc/lib/include/spacepi/protoc/CodeTemplate.hpp
+++ b/protoc/lib/include/spacepi/protoc/CodeTemplate.hpp
@@ -28,7 +28,7 @@ namespace spacepi {
             private:
 
                 //virtual void   getRelfectionPropertyDataBeg  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept = 0;
-                virtual std::string getFullPropertyData (int structureType, std::string propertyType, std::string propertyName, int propertyNumber, const google::protobuf::Descriptor *message_type) const noexcept = 0; 
+                virtual std::string getFullPropertyData (int structureType, const google::protobuf::FieldDescriptor &property) const noexcept = 0; 
                 //virtual void   getReflectionPropertyDataEnd  (CodeStream &os, const google::protobuf::FileDescriptor &file, const google::protobuf::Descriptor &cls) const noexcept = 0;
                 std::string extension;
         };

--- a/protoc/lib/src/CodeGenerator.cpp
+++ b/protoc/lib/src/CodeGenerator.cpp
@@ -44,6 +44,14 @@ bool CodeGenerator::Generate(const FileDescriptor *_file, const string &paramete
                         (*it)->enumValue(os, file, cls, value);
                     }
                     (*it)->enumEnd(os, file, cls);
+
+                    (*it)->enumReflectionBeg(os, file, cls);
+                    for (int j = 0; j < cls.value_count(); ++j) {
+                        const EnumValueDescriptor &value = *cls.value(j);
+                        (*it)->enumReflectionValue(os, file, cls, value);
+                    }
+                    (*it)->enumReflectionEnd(os, file, cls);
+
                     stack.top().second.pop();
                 }
                 if (stack.top().first.empty()) {

--- a/protoc/lib/src/CodeGenerator.cpp
+++ b/protoc/lib/src/CodeGenerator.cpp
@@ -80,12 +80,6 @@ bool CodeGenerator::Generate(const FileDescriptor *_file, const string &paramete
                     (*it)->reflectionMethodProperty(os, file, cls, property);
                 }
                 (*it)->reflectionMethodEnd(os, file, cls);
-                // (*it)->getRelfectionPropertyDataBeg(os, file, cls);
-                // for (int i = 0; i < cls.field_count(); ++i) {
-                //     const FieldDescriptor &property = *cls.field(i);
-                //     (*it)->getReflectionPropertyDataMid(os, file, cls, property);
-                // }
-                // (*it)->getReflectionPropertyDataEnd(os, file, cls);
                 (*it)->classEnd(os, file, cls);
                 stack.top().first.pop();
                 --depth;


### PR DESCRIPTION
This PR should complete #8

The Visual Studio project uses the protoc plugin written in C++ to generate C# reflection code.

The model classes are generated to implement `ModelClass`, however, some property names conflict with properties in the base. Hiding shouldn't be a problem since the base can be accessed with `<model>.Reflection`
